### PR TITLE
Fix fitter tests with mlflow logging

### DIFF
--- a/corescore/api.py
+++ b/corescore/api.py
@@ -1,0 +1,65 @@
+"""API accepting requests sent by LabelTool,
+for use with its ML Assist mode in image annotation
+This is what it should respond with
+
+{
+  "predictions": [
+    {
+       "det_boxes": [<ymin>, <xmin>, <ymax>, <xmax>],
+       "det_class": <str>,
+       "det_score": <0 ~ 1 floating number
+    },
+    ...,
+    ...
+    ]
+}
+
+"""
+
+import base64
+import io
+from typing import List
+
+from fastapi import FastAPI
+import numpy as np
+from PIL import Image
+from pydantic import BaseModel
+
+
+# By default, models from corebreakout's assets.zip
+def load_model():
+    """Load the latest (best scoring) UNet from MLFlow registry"""
+    pass
+
+
+app = FastAPI()
+
+
+# Define classes for what Label-tool accepts
+
+class InputBytes(BaseModel):
+    b64: str
+
+
+class Instance(BaseModel):
+    input_bytes: InputBytes
+
+
+class Instances(BaseModel):
+    instances: List[Instance]
+
+
+@app.post("/labels")
+def core_labels(images: Instances):
+    labels = []
+    for instance in images:
+        labels.append(segment_image(instance))
+    return {"masks": labels}
+
+
+def segment_image(instance: Instance, model=load_model()):
+    image_bytes = base64.decodebytes(instance[1][0].input_bytes.b64.encode())
+    image_arr = np.array(Image.open(io.BytesIO(image_bytes)))
+    # predict
+    # TODO return labelled regions that LabelTool hopes for
+    return {}

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -73,16 +73,14 @@ class CoreModel():
         self.learn.model = torch.nn.DataParallel(self.learn.model)
         self.learn.lr_find()
 
-    def fit(self, epochs=None, lr=5.20E-05):
+    def fit(self, lr=5.20E-05):
         """Fit the model for N epochs (defaults to 10)
         with a learning rate (lr - defaults to %20.E.05
         """
         # TODO fix this to use the model's discovered LR
         if not lr:
             lr = 5.20E-05
-        if not epochs:
-            epochs = self.epochs
-        self.learner().fit_one_cycle(epochs,
+        self.learner().fit_one_cycle(self.epochs,
                                      slice(lr),
                                      pct_start=self.pct_start)
 

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -86,5 +86,4 @@ class CoreModel():
 
     def save(self):
         """Save the model"""
-        # TODO save via MLFLow
-        self.learn.save('model')
+        mlflow.fastai.log_model(self.learner(), "model")

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -67,8 +67,7 @@ class CoreModel():
             models.resnet34,
             metrics=metrics,
             wd=self.wd)
-        self.learn.model = torch.nn.DataParallel(self.learn.model)
-        self.learn.lr_find()
+        return self.learn
 
     def fit(self, lr=5.20E-05):
         """Fit the model for N epochs (defaults to 10)

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -1,24 +1,21 @@
 import os
-import warnings
 from pathlib import Path
 from functools import partial
 
 import numpy as np
-import matplotlib.pyplot as plt
-from torchvision import transforms
 import torch
 import mlflow.fastai
 from fastai.vision import models
 from fastai.vision.transform import get_transforms
 from fastai.vision.learner import unet_learner
 from fastai.vision.image import open_mask
-from fastai.vision.data import get_image_files, SegmentationItemList
-from fastai.vision import imagenet_stats, DatasetType
-CUDA_LAUNCH_BLOCKING = "1"  # better error reporting
-# TODO move to v2 when MLFlow does
-#from fastai.vision.all import *
+from fastai.vision.data import SegmentationItemList
+from fastai.vision import imagenet_stats
 from corescore.masks import LABELS
 
+CUDA_LAUNCH_BLOCKING = "1"  # better error reporting
+# TODO move to v2 when MLFlow does
+# from fastai.vision.all import *
 
 URI = os.environ.get('MLFLOW_TRACKING_URI', '')
 mlflow.fastai.autolog()
@@ -36,7 +33,7 @@ class CoreModel():
         self.wd = wd
         self.pct_start = pct_start
         self.epochs = epochs
-        self.reduce_size = np.array([148, 1048])  # TODO derive from samples e.g. src_size / 6
+        self.reduce_size = np.array([148, 1048])  # TODO derive from samples e.g. src_size / 6 # noqa: E501
 
     def image_src(self):
         """Load images from self.path/images"""

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -92,9 +92,3 @@ class CoreModel():
         """Save the model"""
         # TODO save via MLFLow
         self.learn.save('model')
-
-
-if __name__ == '__main__':
-    coremodel = CoreModel(os.getcwd())
-    coremodel.fit()
-    coremodel.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+fastapi
 numpy
 mlflow
 opencv-python

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,15 @@
+import argparse
+import os
+from corescore.models import CoreModel
+
+def train(epochs=10, path=os.getcwd()):
+    coremodel = CoreModel(path, epochs=epochs)
+    coremodel.fit()
+    coremodel.save()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--epochs', help="Epochs to train, default 10")
+    args = parser.parse_args()
+    train(epochs=args.epochs)
+

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,15 +1,20 @@
 import argparse
 import os
-from corescore.models import CoreModel
 
-def train(epochs=10, path=os.getcwd()):
+from corescore.models import CoreModel
+import mlflow
+
+
+def train(epochs=10, lr=0.00001, path=os.getcwd()):
     coremodel = CoreModel(path, epochs=epochs)
-    coremodel.fit()
+    coremodel.fit(lr=lr)
     coremodel.save()
+        
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--epochs', help="Epochs to train, default 10")
+    parser.add_argument('--lr', help="Learning rate to perform training")
     args = parser.parse_args()
-    train(epochs=args.epochs)
+    train(epochs=int(args.epochs), lr=float(args.lr))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,45 @@
+"""
+API expects an input like this
+{
+  "instances": [
+    {
+      "input_bytes": {
+        "b64": "<str>"
+      }
+    }
+  ]
+}
+"""
+import os
+from base64 import b64encode
+import json
+import pytest
+from fastapi.testclient import TestClient
+from corescore.api import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def image_bytes():
+    sample = 'S00128906.Cropped_Top_2.png'
+    fix_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(fix_dir,
+                           'fixtures',
+                           'images',
+                           'train',
+                           sample), 'rb') as img_file:
+        return b64encode(img_file.read()).decode()
+
+
+def test_labels(image_bytes):
+    body = {'instances': [
+            {'input_bytes': {
+                'b64': image_bytes}}]}
+
+    with open('foo.json', 'w') as json_out:
+        json_out.write(json.dumps(body))
+    response = client.post("/labels", json=body)
+
+    assert response.status_code == 200
+    assert response.json()["masks"]

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -30,5 +30,6 @@ def test_load_processor(image_dir, labels):
         has_data = im_arr.any()
         # Test if mask is blank
         assert has_data
-        if has_data: total += 1
+        if has_data:
+            total += 1
     assert total > 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,26 +1,11 @@
 import os
 import fastai
-import pytest
 from corescore.models import CoreModel
-from corescore.masks import CoreImageProcessor
 
-
-@pytest.fixture
-def image_dir():
-    fix_dir = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        'fixtures')
-    return fix_dir
-
-
-@pytest.fixture
-def make_masks(image_dir):
-    coreProcessor = CoreImageProcessor(image_dir+'Images', labels=labels)
-    for image in coreProcessor.core_types:
-        coreProcessor.processImage(image)
 
 def test_create_model():
     model = CoreModel(os.getcwd())
+    assert model
 
 
 def test_fastai_version():
@@ -38,6 +23,7 @@ def test_image_data():
     model = CoreModel(os.getcwd())
     data = model.image_data()
     assert data
+
 
 def test_fit_one():
     model = CoreModel(os.getcwd(), epochs=1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -38,3 +38,7 @@ def test_image_data():
     model = CoreModel(os.getcwd())
     data = model.image_data()
     assert data
+
+def test_fit_one():
+    model = CoreModel(os.getcwd(), epochs=1)
+    model.fit()


### PR DESCRIPTION
* Tests pass now

The `TypeError:  Logging to MLflow failed: can't pickle weakref objects` is a warning for the fit function now but the tests pass and we don't need any logging for it.

I don't think there is conditional logging function in mlflow and it would be better if the logging is done from the scripts. The logging logic however is working and that would be in another PR.

* lr_find() was removed in https://github.com/BritishGeologicalSurvey/CoreScore/commit/aa40ebb99c70d66fe823d6466d6fdca043d3e95a because it was causing the weakref error. Do we want it back? I didn't really look into how to get the best learning rate from the [fastaiv1 documentation](https://fastai1.fast.ai/callbacks.lr_finder.html#lr_find), this is just a simple fix. 

