### PR TITLE
Model saving in mlflow

### DIFF
--- a/corescore/masks.py
+++ b/corescore/masks.py
@@ -165,11 +165,11 @@ class CoreImageProcessor():
         #       "points": [[ 6184, 1223], etc
         elif 'shapes' in fp:
             for shape in fp['shapes']:
-                 if shape['label'] not in self.mask_labels:
-                     continue
-                 colour = self.masks[shape['label']]
-                 points = [tuple(p) for p in shape['points']]
-                 draw.polygon(points, outline=colour, fill=colour)
+                if shape['label'] not in self.mask_labels:
+                    continue
+                colour = self.masks[shape['label']]
+                points = [tuple(p) for p in shape['points']]
+                draw.polygon(points, outline=colour, fill=colour)
 
         return np.array(image)
 

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -19,7 +19,6 @@ CUDA_LAUNCH_BLOCKING = "1"  # better error reporting
 # from fastai.vision.all import *
 
 URI = os.environ.get('MLFLOW_TRACKING_URI', '')
-mlflow.fastai.autolog()
 mlflow.set_tracking_uri(URI)
 
 

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from functools import partial
 
 import numpy as np
-import torch
 import mlflow
 import mlflow.fastai
 from fastai.vision import models
@@ -62,10 +61,10 @@ class CoreModel():
     def learner(self):
         """Run the UNet learner based on image data"""
         metrics = self.acc_rock
-        return    unet_learner(self.image_data(),
-                               models.resnet34,
-                               metrics=metrics,
-                               wd=self.wd)
+        return unet_learner(self.image_data(),
+                            models.resnet34,
+                            metrics=metrics,
+                            wd=self.wd)
 
     def fit(self, learner, lr=5.20E-05):
         """Fit the model for N epochs (defaults to 10)

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -67,17 +67,16 @@ class CoreModel():
                                metrics=metrics,
                                wd=self.wd)
 
-    def fit(self, lr=5.20E-05):
+    def fit(self, learner, lr=5.20E-05):
         """Fit the model for N epochs (defaults to 10)
         with a learning rate (lr - defaults to %20.E.05
         """
-        learner = self.learner()
         # TODO fix this to use the model's discovered LR
         if not lr:
             lr = 5.20E-05
-        self.learner().fit_one_cycle(self.epochs,
-                                     slice(lr),
-                                     pct_start=self.pct_start)
+        learner.fit_one_cycle(self.epochs,
+                              slice(lr),
+                              pct_start=self.pct_start)
 
     def get_y_fn(self, x):
         """Return a file path to a mask given an image path"""

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -63,17 +63,16 @@ class CoreModel():
     def learner(self):
         """Run the UNet learner based on image data"""
         metrics = self.acc_rock
-        self.learn = unet_learner(
-            self.image_data(),
-            models.resnet34,
-            metrics=metrics,
-            wd=self.wd)
-        return self.learn
+        return    unet_learner(self.image_data(),
+                               models.resnet34,
+                               metrics=metrics,
+                               wd=self.wd)
 
     def fit(self, lr=5.20E-05):
         """Fit the model for N epochs (defaults to 10)
         with a learning rate (lr - defaults to %20.E.05
         """
+        learner = self.learner()
         # TODO fix this to use the model's discovered LR
         if not lr:
             lr = 5.20E-05

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -7,7 +7,8 @@ import mlflow
 def train(epochs=10, lr=0.00001, path=os.getcwd()):
     mlflow.fastai.autolog()
     coremodel = CoreModel(path, epochs=epochs)
-    coremodel.fit(lr=lr)
+    unet_learn = coremodel.learner()
+    coremodel.fit(lr=lr, learner=unet_learn)
 
 
 if __name__ == '__main__':

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -2,13 +2,13 @@ import argparse
 import os
 
 from corescore.models import CoreModel
-
+import mlflow
 
 def train(epochs=10, lr=0.00001, path=os.getcwd()):
+    mlflow.fastai.autolog()
     coremodel = CoreModel(path, epochs=epochs)
     coremodel.fit(lr=lr)
-    coremodel.save()
-        
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,4 +27,5 @@ def test_image_data():
 
 def test_fit_one():
     model = CoreModel(os.getcwd(), epochs=1)
-    model.fit()
+    learn = model.learner()
+    model.fit(learn)


### PR DESCRIPTION
## Issue

* A `UserWarning: Logging to MLflow failed: cannot pickle 'weakref' object` was preventing `mlflow.fastai.autolog()`  from logging the model. The autologging function should log metrics, artifacts and models but it wasn't and with a separate call to `mlflow.fastai.log_model()` we were logging the models but under a different mlflow run. 

The problem was that the `unet_learner()` was passed into a variable and then returned (below), causing mlflow to give a weakref error.
https://github.com/BritishGeologicalSurvey/CoreScore/blob/244248ec49a9579bad43312f9f49392c336255b7/corescore/models.py#L66-L71 

## Fix
* The learner is returned directly by `CoreModel.learner()`  and is passed as an argument to the fit function now. I thought it's a bit cleaner.
* Logging was moved in `scripts/train.py` and models are written under the same mlflow run.
* The CoreModel.save() function was kept for future use.



