### PR TITLE
Resize based on the first input sample

### DIFF
--- a/corescore/models.py
+++ b/corescore/models.py
@@ -32,7 +32,6 @@ class CoreModel():
         self.wd = wd
         self.pct_start = pct_start
         self.epochs = epochs
-#        self.reduce_size = np.array([148, 1048])  # TODO derive from samples e.g. src_size / 6 # noqa: E501
 
     def image_resize(self, sample, resize=4):
         """Accepts a sample image from our training set.

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -51,12 +51,12 @@ class CoreModel():
 
     def image_data(self, resize=4):
         """Load scaled-down source images as data"""
-        self.data = self.image_src()
+        data = self.image_src()
 
         # Resize (based on dimensions of first sample
-        resize_to = self.image_resize(self.data.x[0], resize=resize)
+        resize_to = self.image_resize(data.x[0], resize=resize)
 
-        self.data.transform(
+        self.data = data.transform(
             get_transforms(), size=resize_to, tfm_y=True).databunch(
             bs=self.batch_size, num_workers=0).normalize(imagenet_stats)  # hmm
         return self.data

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -10,7 +10,6 @@ from fastai.vision.transform import get_transforms
 from fastai.vision.learner import unet_learner
 from fastai.vision.image import open_mask
 from fastai.vision.data import SegmentationItemList
-from fastai.vision import imagenet_stats
 from corescore.masks import LABELS
 
 CUDA_LAUNCH_BLOCKING = "1"  # better error reporting
@@ -57,7 +56,7 @@ class CoreModel():
 
         self.data = data.transform(
             get_transforms(), size=resize_to, tfm_y=True).databunch(
-            bs=self.batch_size, num_workers=0).normalize(imagenet_stats)  # hmm
+            bs=self.batch_size, num_workers=0).normalize()
         return self.data
 
     def acc_rock(self, input, target):

--- a/corescore/models.py
+++ b/corescore/models.py
@@ -32,22 +32,32 @@ class CoreModel():
         self.wd = wd
         self.pct_start = pct_start
         self.epochs = epochs
-        self.reduce_size = np.array([148, 1048])  # TODO derive from samples e.g. src_size / 6 # noqa: E501
+#        self.reduce_size = np.array([148, 1048])  # TODO derive from samples e.g. src_size / 6 # noqa: E501
+
+    def image_resize(self, sample, resize=4):
+        """Accepts a sample image from our training set.
+        Returns the dimensions, resized by 1/resize
+        (as a numpy array, to stay close to the original"""
+        # input dimensions are a torch.Size
+        size = sample.size
+        return np.array([int(size[0]/resize), int(size[1]/resize)])
 
     def image_src(self):
         """Load images from self.path/images"""
-        self.src = (
-            SegmentationItemList.from_folder(
-                self.path_img).split_by_rand_pct().label_from_func(
-                    self.get_y_fn, classes=LABELS))  # noqa: E501
+        self.src = (SegmentationItemList.from_folder(self.path_img).split_by_rand_pct().label_from_func(self.get_y_fn, classes=LABELS))  # noqa: E501
         self.src.train.y.create_func = partial(open_mask, div=True)
         self.src.valid.y.create_func = partial(open_mask, div=True)
         return self.src
 
-    def image_data(self):
+    def image_data(self, resize=4):
         """Load scaled-down source images as data"""
-        self.data = self.image_src().transform(
-            get_transforms(), size=self.reduce_size, tfm_y=True).databunch(
+        self.data = self.image_src()
+
+        # Resize (based on dimensions of first sample
+        resize_to = self.image_resize(self.data.x[0], resize=resize)
+
+        self.data.transform(
+            get_transforms(), size=resize_to, tfm_y=True).databunch(
             bs=self.batch_size, num_workers=0).normalize(imagenet_stats)  # hmm
         return self.data
 
@@ -58,10 +68,10 @@ class CoreModel():
         mask = target != LABELS.index("Void")
         return (input.argmax(dim=1)[mask] == target[mask]).float().mean()
 
-    def learner(self):
+    def learner(self, resize=4):
         """Run the UNet learner based on image data"""
         metrics = self.acc_rock
-        return unet_learner(self.image_data(),
+        return unet_learner(self.image_data(resize=resize),
                             models.resnet34,
                             metrics=metrics,
                             wd=self.wd)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -66,7 +66,7 @@ def test_image_data():
 def test_fit_one(image_tensor):
     """Very short training run and test prediction values"""
     model = CoreModel(os.getcwd(), epochs=1)
-    learn = model.learner()
+    learn = model.learner(resize=12)
     model.fit(learn)
     # test a prediction
     _, mask, _ = learn.predict(image_tensor)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,23 +28,43 @@ def test_create_model():
 
 
 def test_fastai_version():
+    """Check this is v1 (needed for mlflow support)"""
     major = fastai.__version__.split('.')[0]
     assert int(major) == 1
 
 
 def test_image_src():
+    """Test we can load images with test/validation split"""
     model = CoreModel(os.getcwd())
     src = model.image_src()
     assert src
 
 
+def test_resize():
+    """Test we are resizing inputs based on default/supplied size
+    """
+    model = CoreModel(os.getcwd())
+    src = model.image_src()
+    # This is a LabelList with train / valid beneath x and y attributes
+    sample = src.x.get(0)
+    orig_size = sample.size
+    new_size = model.image_resize(sample)
+    assert int(orig_size[0]/4) == new_size[0]
+
+    # Check we can overrode the value
+    new_size = model.image_resize(sample, resize=2)
+    assert int(orig_size[0]/2) == new_size[0]
+
+
 def test_image_data():
+    """Test the transforms being applied to the inputs"""
     model = CoreModel(os.getcwd())
     data = model.image_data()
     assert data
 
 
 def test_fit_one(image_tensor):
+    """Very short training run and test prediction values"""
     model = CoreModel(os.getcwd(), epochs=1)
     learn = model.learner()
     model.fit(learn)


### PR DESCRIPTION
I added a function to resize the input using the dimensions of the first training image and an optional `resize` parameter for how far to shrink the input images. The `resize` parameter gets passed around internally a bit too much, but I don't think it's excessive.

The original test fail was due to not replacing the `LabelList` when transforming it. It looks all right now but also draws my eye to the use of `normalise(imagenet_stats)` in the original. This should be intended for transfer learning from ImageNet, but we're building from scratch, and it looks like there's a reasonable default:  https://fastai1.fast.ai/vision.data.html#ImageDataBunch.normalize
