### PR TITLE
Small change to add resize option to train script

### DIFF
--- a/Images/train/Training images
+++ b/Images/train/Training images
@@ -1,1 +1,0 @@
-Training images stored here

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -5,11 +5,11 @@ from corescore.models import CoreModel
 from corescore.mlflowregistry import MlflowRegistry
 import mlflow
 
-def train(epochs=10, lr=0.00001, path=os.getcwd()):
+def train(epochs=10, lr=0.00001, resize=8, path=os.getcwd()):
     mlflow.fastai.autolog()
     mlflow.set_tag('model', 'corescore')
     coremodel = CoreModel(path, epochs=epochs)
-    unet_learn = coremodel.learner()
+    unet_learn = coremodel.learner(resize=resize)
     coremodel.fit(lr=lr, learner=unet_learn)
 
 
@@ -21,11 +21,15 @@ if __name__ == '__main__':
     parser.add_argument('--lr',
                         default=0.00001,
                         help="Learning rate to perform training")
+    parser.add_argument('--resize',
+                        default=8,
+                        help="Scale image input down by this proportion")
+
     args = parser.parse_args()
 
     # Run the training loop
-    train(epochs=int(args.epochs), lr=float(args.lr))
+    train(epochs=int(args.epochs), lr=float(args.lr), resize=int(args.resize))
 
     # Register the model
-    MlflowRegistry().register_model("tags.model = 'corescore'",
-                                    name="corescore")
+    #MlflowRegistry().register_model("tags.model = 'corescore'",
+    #                                name="corescore")


### PR DESCRIPTION
Set the default to 8 when invoked this way (4 is slow on CPU and won't run at all on my home GPU, insufficient memory)

However we should compare prediction quality / metric similarity on different resize values


