### PR TITLE
Add sleep(300) to ensure the model artifacts are saved before registering

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,5 +1,5 @@
 import argparse
-from time import sleepvi 
+from time import sleep
 import os
 
 from corescore.models import CoreModel

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,5 @@
 import argparse
+from time import sleepvi 
 import os
 
 from corescore.models import CoreModel
@@ -41,3 +42,6 @@ if __name__ == '__main__':
     # Picks up MLFLOW_TRACKING_URI from environment.
     MlflowRegistry().register_model("tags.model = 'corescore'",
                                     name="corescore")
+    
+    # Long sleep to ensure model version is created
+    sleep(300)


### PR DESCRIPTION
Sleep cycle of 60 hasn't proved enough for larger models, and the registry client is issuing the following warning set at 300 seconds, so sleep accordingly.

https://github.com/mlflow/mlflow/blob/3935ad1cd9cb556ac931de9ed5c7c9538a3a8281/mlflow/tracking/_model_registry/client.py#L199

As you suggested @mobiuscreek doing this here rather than in the CI pipeline makes it much simpler to track specific changes when errors occur! 