### PR TITLE
Fix registry

### DIFF
--- a/corescore/mlflowregistry.py
+++ b/corescore/mlflowregistry.py
@@ -8,16 +8,15 @@ class MlflowRegistryError(Exception):
 
 
 class MlflowRegistry(MlflowClient):
-    def __init__(self, registry_uri=None, *args, **kwargs):
-        self.client = MlflowClient(registry_uri)
-        super().__init__(registry_uri=registry_uri, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def list_experiments(self, query):
         """Query the mlflow api and return
            a list of experiment dictionaries"""
         runs_list = []
-        search_result = self.client.search_runs(experiment_ids="0",
-                                                filter_string=query)
+        search_result = self.search_runs(experiment_ids="0",
+                                         filter_string=query)
         for run in search_result:
             runs_list.append(run.to_dictionary())
         return runs_list
@@ -39,7 +38,7 @@ class MlflowRegistry(MlflowClient):
     def list_models(self):
         """Return a list of registered models"""
         registered_models = []
-        for rm in self.client.list_registered_models():
+        for rm in self.list_registered_models():
             registered_models.append(rm)
         return registered_models
 
@@ -48,7 +47,7 @@ class MlflowRegistry(MlflowClient):
             Return model's path """
         filter_str = f"name='{name}'"
         if version:
-             models = self.client.search_model_versions(filter_string=filter_str)
+             models = self.search_model_versions(filter_string=filter_str)
              if not models:
                  raise MlflowRegistryError(f'Model named {name} does not exist')
              model = list(filter(lambda model: model.version == version,  models))

--- a/corescore/mlflowregistry.py
+++ b/corescore/mlflowregistry.py
@@ -8,9 +8,9 @@ class MlflowRegistryError(Exception):
 
 
 class MlflowRegistry(MlflowClient):
-    def __init__(self, client=None, *args, **kwargs):
-        self.client = MlflowClient(client)
-        super().__init__(*args, **kwargs)
+    def __init__(self, registry_uri=None, *args, **kwargs):
+        self.client = MlflowClient(registry_uri)
+        super().__init__(registry_uri=registry_uri, *args, **kwargs)
 
     def list_experiments(self, query):
         """Query the mlflow api and return

--- a/tests/test_mlflow_api.py
+++ b/tests/test_mlflow_api.py
@@ -6,22 +6,37 @@ from mlflow.entities import (RunData,
                              Metric,
                              Param,
                              RunTag)
-from mlflow.entities.model_registry import RegisteredModel
+
+from mlflow.entities.model_registry import RegisteredModel, ModelVersion
+from mlflow.pyfunc import PyFuncModel
 import pytest
 
 from corescore.mlflowregistry import MlflowRegistry, MlflowRegistryError
 
 
-@patch('mlflow.tracking.client.MlflowClient.list_registered_models',
-       return_value=[RegisteredModel('test_model')])
-def test_list_models(*args):
-    client = MlflowRegistry()
-    assert isinstance(client.list_models(), list)
-    assert isinstance(client.list_models()[0], RegisteredModel)
+def mock_search_registered_models(*args, **kwargs):
+    response = [RegisteredModel(name='corescore',
+                                latest_versions=[ModelVersion(name='corescore',
+                                version='1',
+                                creation_timestamp=222,
+                                current_stage='Production',
+                                source='/var/lib')])]*2
+    return response
+
+def mock_search_model_versions(*args, **kwargs):
+    if 'corescore' in kwargs['filter_string']:
+        response = [ModelVersion(name='corescore',
+                                 version='1',
+                                 creation_timestamp=222,
+                                 current_stage='Production',
+                                 source='/var/lib/')]*2
+        return response
+    else:
+        return []
 
 
 def mock_response(*args, **kwargs):
-    if "corescore" in kwargs['filter_string']:
+    if 'corescore' in kwargs['filter_string']:
         mock_run = Run(
             run_data=RunData(
                 metrics=[
@@ -57,6 +72,14 @@ def mock_response(*args, **kwargs):
         return []
 
 
+@patch('mlflow.tracking.client.MlflowClient.list_registered_models',
+       return_value=[RegisteredModel('test_model')])
+def test_list_models(*args):
+    client = MlflowRegistry()
+    assert isinstance(client.list_models(), list)
+    assert isinstance(client.list_models()[0], RegisteredModel)
+
+
 @patch('mlflow.tracking.client.MlflowClient.search_runs',
        side_effect=mock_response)
 def test_list_experiments(*args):
@@ -72,3 +95,43 @@ def test_register_model(*args):
     client = MlflowRegistry()
     with pytest.raises(MlflowRegistryError):
         assert client.register_model(query='tag.model = "random_name"')
+
+
+@patch('mlflow.tracking.client.MlflowClient.search_model_versions',
+       side_effect =mock_search_model_versions)
+@patch('mlflow.tracking.client.MlflowClient.list_registered_models',
+       side_effect=mock_search_registered_models)
+def test_find_model_error(*args):
+    client = MlflowRegistry()
+    with pytest.raises(MlflowRegistryError) as exc_info:
+         model_path = client._find_model(name='blah')
+    assert 'named' in str(exc_info.value)
+    
+    with pytest.raises(MlflowRegistryError) as exc_info:
+         model_path = client._find_model(name='corescore', version='9999')
+    assert 'version' in str(exc_info.value)
+    
+    with pytest.raises(MlflowRegistryError) as exc_info:
+         model_path = client._find_model(name='blah', version='1')
+    assert 'blah' in str(exc_info.value)    
+
+
+@patch('mlflow.tracking.client.MlflowClient.list_registered_models',
+       side_effect=mock_search_registered_models)
+@patch('mlflow.tracking.client.MlflowClient.search_model_versions',
+       side_effect=mock_search_model_versions)
+def test_find_model(*args):
+    client = MlflowRegistry()
+    model_path = client._find_model(name='corescore')
+    assert '/var/' in model_path
+    model_path = client._find_model(name='corescore', version='1')
+    assert '/var/' in model_path
+
+
+@patch('mlflow.pyfunc.load_model', return_value=PyFuncModel)
+@patch('corescore.mlflowregistry.MlflowRegistry._find_model', return_value='/var/lib/mlflow/model')
+def test_load_model(*args):
+    client = MlflowRegistry()
+    model = client.load_model()
+    assert model == PyFuncModel 
+


### PR DESCRIPTION
This PR fixes an issue with the `registry_uri` attribute that was not correctly passed to the MlflowClient. It simplifies the `load_model` function that now only...loads a model. The rest of the old `load_model` functionality is part of a new `_find_model` function that retrieves the model's path to be passed to the `load_model`.

New tests were implemented for the new functions that I hope make sense.
