### PR TITLE
option to merge rock fragment labels (set in script)

### DIFF
--- a/corescore/masks.py
+++ b/corescore/masks.py
@@ -32,7 +32,7 @@ LABELS = [
 
 
 class CoreImageProcessor():
-    '''
+    """
         Class that handles all the preprocessing to make the image
         masks and lower the resolution of the images as defined by a
         constant in the file - some things need to be reworked -
@@ -41,18 +41,16 @@ class CoreImageProcessor():
         figured out not via constants
 
         Class takes in the image directory as a string
-    '''
-
-    # Map of greyscale colours to use as masks
-    masks = {value: index for (index, value) in enumerate(LABELS)}
+    """
 
     def __init__(self, imageDirectory,
                  labels="Core_labels.json",
+                 merge_fragment_labels=None,
                  mask_labels=[]):
         """Takes an image directory,
-        a set of associated labels,
-        and optional list of labels to use for masks
-        (defaults to "Rock_Fragment")
+        A set of associated labels for each image filename,
+        Optional list of labels to use for masks,
+        Optional whether to label Rock_Fragment and Rock_Fragment_2 together
         """
 
         self.path = os.fspath(Path(imageDirectory))
@@ -63,6 +61,12 @@ class CoreImageProcessor():
             self.mask_labels = mask_labels
         else:
             self.mask_labels = LABELS
+
+        # Map of greyscale colours to use as masks
+        self.masks = {value: index for (index, value) in enumerate(LABELS)}
+
+        if merge_fragment_labels:
+            self.masks['Rock_Fragment_2'] = self.masks['Rock_Fragment']
 
     def getImageNames(self, image):
         """Returns image name from LabelBox compat data"""

--- a/scripts/make_masks.py
+++ b/scripts/make_masks.py
@@ -4,7 +4,11 @@ from corescore.masks import CoreImageProcessor
 
 
 def process_images(image_dir, labels):
-    coreProcessor = CoreImageProcessor("Images", labels=labels)
+    """Create masks for labelled images.
+    For now, merge rock fragment labels from both core boxes"""
+    coreProcessor = CoreImageProcessor("Images",
+                                        labels=labels,
+                                        merge_fragment_labels=True)
     for image in coreProcessor.core_types:
         mask_file = coreProcessor.processImage(image)
 

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -56,3 +56,10 @@ def test_load_labeltool(image_dir, labeltool_labels):
         if has_data:
             total += 1
     assert total > 1
+
+
+def test_merge_labels():
+    coreProc = CoreImageProcessor('Images', merge_fragment_labels=True)
+    assert coreProc.masks['Rock_Fragment'] == coreProc.masks['Rock_Fragment_2']
+    coreProc = CoreImageProcessor('Images')
+    assert coreProc.masks['Rock_Fragment'] != coreProc.masks['Rock_Fragment_2']


### PR DESCRIPTION
Adds the small change that we discussed in the last mob session, adding an option to merge the rock fragment labels when creating the training masks.